### PR TITLE
fix: reset ota manifest struct when parsing new one

### DIFF
--- a/components/golioth_sdk/golioth_ota.c
+++ b/components/golioth_sdk/golioth_ota.c
@@ -85,6 +85,7 @@ golioth_status_t golioth_ota_payload_as_manifest(
         size_t payload_len,
         golioth_ota_manifest_t* manifest) {
     golioth_status_t ret = GOLIOTH_OK;
+    memset(manifest, 0, sizeof(*manifest));
 
     cJSON* json = cJSON_ParseWithLength((const char*)payload, payload_len);
     if (!json) {


### PR DESCRIPTION
I noticed that when I create new releases and the backend notifies the device of new versions, the device was always sticking with the first manifest that it got when starting the observation on the endpoint.

I think due to this line, when we have multiple notification on new version, this `num_components` keeps increasing:

```
golioth_ota_component_t* c = &manifest->components[manifest->num_components++];
```

So per @ncmiller suggestion, we can reset the OTA Manifest struct on the method `golioth_ota_payload_as_manifest` wherever we receive a new manifest to be parsed.

```
memset(manifest, 0, sizeof(*manifest));
```

Test scenario without the fix:
* Device running version 1.2.8
* On boot, it checks with our server and the latest release is indeed 1.2.8, so no updates
* Them I set rollout flag to false on release 1.2.8
* Device receives notification over Coap, that the latest now is 1.2.7. I see the device receiving the notification, but the logs outputs this:
```
I (3917) fw_update: Waiting to receive OTA manifest
I (4537) fw_update: Received OTA manifest
I (4537) fw_update: Manifest does not contain different firmware version. Nothing to do.
I (4537) fw_update: Waiting to receive OTA manifest
```
* So the device stays o 1.2.8.
* If I reboot the device, it starts the COAP observe again, but this time, it gets the manifest with version 1.2.7 and download the previous version

Test Scenario with the fix:
* Device running version 1.2.8
* On boot, it checks with our server and the latest release is indeed 1.2.8, so no updates
* Them I set rollout flag to false on release 1.2.8
* Device receives notification over Coap, that the latest now is 1.2.7. Download starts for 1.2.7 as expected

The scenario is the same when I’m doing an upgrade, so if I create version 1.2.9 for example and notify the device of a newer version.