### PR TITLE
golioth_coap_client: copy user's path

### DIFF
--- a/components/golioth_sdk/Kconfig
+++ b/components/golioth_sdk/Kconfig
@@ -84,4 +84,11 @@ config GOLIOTH_OTA_MAX_NUM_COMPONENTS
     help
         Maximum number of components in an OTA manifest
 
+config GOLIOTH_COAP_MAX_PATH_LEN
+    int "Golioth maximum CoAP path length"
+    default 39
+    help
+        Maximum length of a CoAP path (everything after
+        "coaps://coap.golioth.io/").
+
 endmenu

--- a/components/golioth_sdk/priv_include/golioth_coap_client.h
+++ b/components/golioth_sdk/priv_include/golioth_coap_client.h
@@ -16,9 +16,9 @@
 
 typedef struct {
     // The CoAP path string (everything after coaps://coap.golioth.io/).
-    // Assumption: path is a string literal (i.e. we don't need to strcpy).
+    // Assumption: path_prefix is a string literal (i.e. we don't need to strcpy).
     const char* path_prefix;
-    const char* path;
+    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     // Must be one of:
     //   COAP_MEDIATYPE_APPLICATION_JSON
     //   COAP_MEDIATYPE_APPLICATION_CBOR
@@ -32,7 +32,7 @@ typedef struct {
 
 typedef struct {
     const char* path_prefix;
-    const char* path;
+    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint32_t content_type;
     golioth_get_cb_fn callback;
     void* arg;
@@ -40,7 +40,7 @@ typedef struct {
 
 typedef struct {
     const char* path_prefix;
-    const char* path;
+    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint32_t content_type;
     size_t block_index;
     size_t block_size;
@@ -50,12 +50,12 @@ typedef struct {
 
 typedef struct {
     const char* path_prefix;
-    const char* path;
+    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
 } golioth_coap_delete_params_t;
 
 typedef struct {
     const char* path_prefix;
-    const char* path;
+    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint32_t content_type;
     golioth_get_cb_fn callback;
     void* arg;


### PR DESCRIPTION
The prior assumption was that all path strings are
const static string literals, such that the CoAP task
can access the string at any point in time without
worrying about memory lifetime.

However, this is not always the case, and it’s not obvious
that this is the assumption being made (unless one reads
the SDK comments and code carefully). It can be surprising
to user's if they are using a dynamically generated path.

Instead, copy the user's path and store it in the request.

Signed-off-by: Nick Miller <nick@golioth.io>