### PR TITLE
ci_on_hardware.yml: run on push to main

### DIFF
--- a/.github/workflows/ci_on_hardware.yml
+++ b/.github/workflows/ci_on_hardware.yml
@@ -2,7 +2,7 @@ name: Test on Hardware
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Previously, was not running ci_on_hardware workflow on merges
to main, because the workflow file had "master" instead of
"main" for on:push:branches.

Signed-off-by: Nick Miller <nick@golioth.io>