### PR TITLE
Kconfig: reduce default queue and stack size

### DIFF
--- a/components/golioth_sdk/Kconfig
+++ b/components/golioth_sdk/Kconfig
@@ -29,7 +29,7 @@ config GOLIOTH_COAP_REQUEST_QUEUE_TIMEOUT_MS
 
 config GOLIOTH_COAP_REQUEST_QUEUE_MAX_ITEMS
     int "CoAP request queue max num items"
-    default 20
+    default 10
     help
         The size, in items, of the CoAP task request queue.
         If the queue is full, any attempts to queue new messages
@@ -43,7 +43,7 @@ config GOLIOTH_COAP_TASK_PRIORITY
 
 config GOLIOTH_COAP_TASK_STACK_SIZE_BYTES
     int "Golioth CoAP task stack size"
-    default 8192
+    default 4096
     help
         FreeRTOS task stack size of the Golioth CoAP task, in bytes.
 

--- a/components/golioth_sdk/golioth_coap_client.c
+++ b/components/golioth_sdk/golioth_coap_client.c
@@ -151,10 +151,6 @@ static coap_response_t coap_response_handler(
         ESP_LOGD(TAG, "%d.%02d (unsolicited), len %zu", class, code, data_len);
     }
 
-    if (sent) {
-        coap_show_pdu(LOG_INFO, sent);
-    }
-
     if (token_matches_request(received, client)) {
         client->got_coap_response = true;
         client->response = response;


### PR DESCRIPTION
Reduce Golioth client queue from 20 to 10. For most users,
10 is expected to be a reasonable number. Also, reducing
it saves heap used to store requests (roughly 64 bytes per
queue item, so 640 bytes saved by reducing).

Also - reduce default stack size from 8192 to 4096.
Testing has shown that the Golioth client typically uses
around 3 KB of stack (see test_client_task_stack_min_remaining),
so 4096 should be enough.

Signed-off-by: Nick Miller <nick@golioth.io>