### PR TITLE
coap_client: only request keepalive if queue empty

### DIFF
--- a/components/golioth_sdk/include/golioth_client.h
+++ b/components/golioth_sdk/include/golioth_client.h
@@ -65,4 +65,5 @@ void golioth_client_register_event_callback(
 
 // Testing and instrumentation
 uint32_t golioth_client_task_stack_min_remaining(golioth_client_t client);
+uint32_t golioth_client_num_items_in_request_queue(golioth_client_t client);
 void golioth_client_set_packet_loss_percent(uint8_t percent);  // 0 to 100


### PR DESCRIPTION
In cases where requests take a long time to complete, or when
there is no connectivity, the keepalive timer might fire
multiple times, littering the request queue with keepalives.

The keepalive is only intended for cases where the queue is
empty, so check for that before enqueueing.

Signed-off-by: Nick Miller <nick@golioth.io>