### PR TITLE
coap_client: fixes for synchronous instability

### DIFF
--- a/components/golioth_sdk/golioth_lightdb.c
+++ b/components/golioth_sdk/golioth_lightdb.c
@@ -410,7 +410,7 @@ golioth_status_t golioth_lightdb_get_int_sync(
             &response,
             true,
             timeout_s);
-    if (response.is_null) {
+    if (status == GOLIOTH_OK && response.is_null) {
         return GOLIOTH_ERR_NULL;
     }
     return status;
@@ -433,7 +433,7 @@ golioth_status_t golioth_lightdb_get_bool_sync(
             &response,
             true,
             timeout_s);
-    if (response.is_null) {
+    if (status == GOLIOTH_OK && response.is_null) {
         return GOLIOTH_ERR_NULL;
     }
     return status;
@@ -456,7 +456,7 @@ golioth_status_t golioth_lightdb_get_float_sync(
             &response,
             true,
             timeout_s);
-    if (response.is_null) {
+    if (status == GOLIOTH_OK && response.is_null) {
         return GOLIOTH_ERR_NULL;
     }
     return status;
@@ -481,7 +481,7 @@ golioth_status_t golioth_lightdb_get_string_sync(
             &response,
             true,
             timeout_s);
-    if (response.is_null) {
+    if (status == GOLIOTH_OK && response.is_null) {
         return GOLIOTH_ERR_NULL;
     }
     return status;

--- a/components/golioth_sdk/golioth_ota.c
+++ b/components/golioth_sdk/golioth_ota.c
@@ -32,7 +32,7 @@ const golioth_ota_component_t* golioth_ota_find_component(
         const char* package) {
     // Scan the manifest until we find the component with matching package.
     const golioth_ota_component_t* found = NULL;
-    for (int i = 0; i < manifest->num_components; i++) {
+    for (size_t i = 0; i < manifest->num_components; i++) {
         const golioth_ota_component_t* c = &manifest->components[i];
         bool matches = (0 == strcmp(c->package, package));
         if (matches) {

--- a/components/golioth_sdk/include/golioth_time.h
+++ b/components/golioth_sdk/include/golioth_time.h
@@ -11,7 +11,7 @@
 #define GOLIOTH_WAIT_FOREVER -1
 
 // Time since boot
-uint64_t golioth_time_micros();
-uint64_t golioth_time_millis();
+uint64_t golioth_time_micros(void);
+uint64_t golioth_time_millis(void);
 
 void golioth_time_delay_ms(uint32_t ms);

--- a/components/golioth_sdk/priv_include/golioth_coap_client.h
+++ b/components/golioth_sdk/priv_include/golioth_coap_client.h
@@ -10,15 +10,16 @@
 #include <freertos/task.h>
 #include <freertos/semphr.h>
 #include <freertos/timers.h>
+#include <freertos/event_groups.h>
 #include <coap3/coap.h>  // COAP_MEDIATYPE_*
 #include "golioth_client.h"
 #include "golioth_lightdb.h"
 
+/// Event group bits for request_complete_event
+#define RESPONSE_RECEIVED_EVENT_BIT (1 << 0)
+#define RESPONSE_TIMEOUT_EVENT_BIT (1 << 1)
+
 typedef struct {
-    // The CoAP path string (everything after coaps://coap.golioth.io/).
-    // Assumption: path_prefix is a string literal (i.e. we don't need to strcpy).
-    const char* path_prefix;
-    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     // Must be one of:
     //   COAP_MEDIATYPE_APPLICATION_JSON
     //   COAP_MEDIATYPE_APPLICATION_CBOR
@@ -33,16 +34,12 @@ typedef struct {
 } golioth_coap_post_params_t;
 
 typedef struct {
-    const char* path_prefix;
-    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint32_t content_type;
     golioth_get_cb_fn callback;
     void* arg;
 } golioth_coap_get_params_t;
 
 typedef struct {
-    const char* path_prefix;
-    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint32_t content_type;
     size_t block_index;
     size_t block_size;
@@ -51,15 +48,11 @@ typedef struct {
 } golioth_coap_get_block_params_t;
 
 typedef struct {
-    const char* path_prefix;
-    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     golioth_set_cb_fn callback;
     void* arg;
 } golioth_coap_delete_params_t;
 
 typedef struct {
-    const char* path_prefix;
-    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
     uint32_t content_type;
     golioth_get_cb_fn callback;
     void* arg;
@@ -76,11 +69,13 @@ typedef enum {
 } golioth_coap_request_type_t;
 
 typedef struct {
+    // The CoAP path string (everything after coaps://coap.golioth.io/).
+    // Assumption: path_prefix is a string literal (i.e. we don't need to strcpy).
+    const char* path_prefix;
+    char path[CONFIG_GOLIOTH_COAP_MAX_PATH_LEN + 1];
+    uint8_t token[8];
+    size_t token_len;
     golioth_coap_request_type_t type;
-    /// Time (since boot) in milliseconds when request is no longer valid.
-    /// This is checked when reqeusts are pulled out of the queue and when responses are received.
-    /// Primarily intended to be used for synchronous requests, to avoid blocking forever.
-    uint64_t ageout_ms;
     union {
         golioth_coap_get_params_t get;
         golioth_coap_get_block_params_t get_block;
@@ -88,14 +83,33 @@ typedef struct {
         golioth_coap_delete_params_t delete;
         golioth_coap_observe_params_t observe;
     };
-    SemaphoreHandle_t request_complete_sem;
+    /// Time (since boot) in milliseconds when request is no longer valid.
+    /// This is checked when reqeusts are pulled out of the queue and when responses are received.
+    /// Primarily intended to be used for synchronous requests, to avoid blocking forever.
+    uint64_t ageout_ms;
+    bool got_response;
+
+    /// (sync request only) Notification from coap task to user sync function that
+    /// request is completed.
+    /// Created in user sync function, deleted by coap task.
+    ///
+    /// Bit 0: response received
+    /// Bit 1: timeout
+    EventGroupHandle_t request_complete_event;
+
+    /// (sync request only) Notification from user sync function to coap task, acknowledge it
+    /// received request_complete_event.
+    ///
+    /// Created in user sync function, deleted by coap task.
+    ///
+    /// Used by the coap task to know when it's safe
+    /// to delete request_complete_event and this semaphore.
+    SemaphoreHandle_t request_complete_ack_sem;
 } golioth_coap_request_msg_t;
 
 typedef struct {
     bool in_use;
-    golioth_coap_observe_params_t req_params;
-    uint8_t token[8];
-    size_t token_len;
+    golioth_coap_request_msg_t req;
 } golioth_coap_observe_info_t;
 
 golioth_status_t golioth_coap_client_empty(

--- a/examples/test/verify.py
+++ b/examples/test/verify.py
@@ -130,7 +130,11 @@ def main():
     reset(ser)
 
     # Run built in tests on the device and check output
-    num_test_failures = run_built_in_tests(ser)
+    for _ in range(1):
+        num_test_failures = run_built_in_tests(ser)
+        if num_test_failures != 0:
+            break
+        reset(ser)
 
     if num_test_failures == 0:
         run_ota_test(ser)


### PR DESCRIPTION
Previously, the way semaphores were used in the synchronous
client transactions was incorrect, causing undefined behavior
in cases where the semaphore was accessed after the *_sync API
had already returned. This caused spurious crashes and test
failures.

To resolve the issue, the *_sync APIs now use a FreeRTOS
event group, for the CoAP task to notify the user task that
the request has been completed, with one event group bit
to indicate "response received" and another for "timeout".
The ownership of the event group is transferred from user task
to CoAP task at the time of enqueueing the request, and the
CoAP task frees the event group after the request is processed.

To safely delete the event group, the CoAP task must know
when the user task has received the event group notification,
so an additional semaphore is added for the user task to
notify the CoAP thread when the event has been received, and
it's safe to delete both the event group and semaphore.

Signed-off-by: Nick Miller <nick@golioth.io>