### PR TITLE
move fw_update into sdk as golioth_fw_update

### DIFF
--- a/components/golioth_sdk/CMakeLists.txt
+++ b/components/golioth_sdk/CMakeLists.txt
@@ -40,14 +40,16 @@ idf_component_register(
         "json"
         "lwip"
         "mbedtls"
+        "app_update"
     SRCS
+        "${libcoap_srcs}"
         "golioth_status.c"
         "golioth_coap_client.c"
         "golioth_log.c"
         "golioth_lightdb.c"
         "golioth_ota.c"
         "golioth_time.c"
-        "${libcoap_srcs}")
+        "golioth_fw_update.c")
 
 list(APPEND EXTRA_C_FLAGS_LIST -Werror)
 component_compile_options(${EXTRA_C_FLAGS_LIST})

--- a/components/golioth_sdk/golioth_fw_update.c
+++ b/components/golioth_sdk/golioth_fw_update.c
@@ -10,9 +10,9 @@
 #include "esp_flash_partitions.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
-#include "fw_update.h"
+#include "golioth_fw_update.h"
 
-#define TAG "fw_update"
+#define TAG "golioth_fw_update"
 
 static golioth_client_t _client;
 static const char* _current_version;
@@ -348,7 +348,7 @@ static void fw_update_task(void* arg) {
     }
 }
 
-void fw_update_init(golioth_client_t client, const char* current_version) {
+void golioth_fw_update_init(golioth_client_t client, const char* current_version) {
     static bool initialized = false;
 
     ESP_LOGI(TAG, "Current firmware version: %s", current_version);

--- a/components/golioth_sdk/include/golioth.h
+++ b/components/golioth_sdk/include/golioth.h
@@ -11,3 +11,4 @@
 #include "golioth_lightdb.h"
 #include "golioth_ota.h"
 #include "golioth_time.h"
+#include "golioth_fw_update.h"

--- a/components/golioth_sdk/include/golioth_fw_update.h
+++ b/components/golioth_sdk/include/golioth_fw_update.h
@@ -8,4 +8,4 @@
 #include "golioth.h"
 
 // Create a task that will perform firmware updates
-void fw_update_init(golioth_client_t client, const char* current_version);
+void golioth_fw_update_init(golioth_client_t client, const char* current_version);

--- a/examples/golioth_basics/main/CMakeLists.txt
+++ b/examples/golioth_basics/main/CMakeLists.txt
@@ -5,7 +5,6 @@ idf_component_register(
         "app_main.c"
         "../../common/shell.c"
         "../../common/wifi.c"
-        "../../common/fw_update.c"
         "../../common/nvs.c"
     PRIV_REQUIRES
         "golioth_sdk"
@@ -13,7 +12,6 @@ idf_component_register(
         "spi_flash"
         "nvs_flash"
         "json"
-        "app_update"
 )
 list(APPEND EXTRA_C_FLAGS_LIST
     -Werror

--- a/examples/golioth_basics/main/app_main.c
+++ b/examples/golioth_basics/main/app_main.c
@@ -11,7 +11,6 @@
 #include "nvs.h"
 #include "shell.h"
 #include "wifi.h"
-#include "fw_update.h"
 #include "golioth.h"
 
 #define TAG "golioth_example"
@@ -115,7 +114,7 @@ void app_main(void) {
     assert(client);
 
     // Spawn background task that will perform firmware updates (aka OTA update)
-    fw_update_init(client, _current_version);
+    golioth_fw_update_init(client, _current_version);
 
     golioth_client_register_event_callback(client, on_client_event, NULL);
 

--- a/examples/test/main/CMakeLists.txt
+++ b/examples/test/main/CMakeLists.txt
@@ -6,7 +6,6 @@ idf_component_register(
         "../../common/wifi.c"
         "../../common/nvs.c"
         "../../common/shell.c"
-        "../../common/fw_update.c"
     PRIV_REQUIRES
         "golioth_sdk"
         "console"

--- a/examples/test/main/app_main.c
+++ b/examples/test/main/app_main.c
@@ -14,7 +14,6 @@
 #include "wifi.h"
 #include "time.h"
 #include "shell.h"
-#include "fw_update.h"
 #include "util.h"
 #include "golioth.h"
 
@@ -260,7 +259,7 @@ static int start_ota(int argc, char** argv) {
         test_golioth_client_create();
         test_connects_to_golioth();
     }
-    fw_update_init(_client, _current_version);
+    golioth_fw_update_init(_client, _current_version);
     return 0;
 }
 


### PR DESCRIPTION
Firmware update is a core service provided by the
SDK, so it makes sense to place it in the SDK instead
of in example apps.

Signed-off-by: Nick Miller <nick@golioth.io>