### PR TITLE
cmake: remove third_party in EXTRA_COMPONENT_DIRS

### DIFF
--- a/examples/golioth_basics/CMakeLists.txt
+++ b/examples/golioth_basics/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-
-set(EXTRA_COMPONENT_DIRS
-    # Golioth components and dependencies
-    ../../components/third_party
-    ../../components
-)
-
+set(EXTRA_COMPONENT_DIRS ../../components)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(golioth_basics)

--- a/examples/magtag_demo/CMakeLists.txt
+++ b/examples/magtag_demo/CMakeLists.txt
@@ -1,9 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-
-set(EXTRA_COMPONENT_DIRS
-    ../../components/third_party
-    ../../components
-)
-
+set(EXTRA_COMPONENT_DIRS ../../components)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(magtag_demo)

--- a/examples/test/CMakeLists.txt
+++ b/examples/test/CMakeLists.txt
@@ -1,10 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
-
-set(EXTRA_COMPONENT_DIRS
-    # Golioth components and dependencies
-    ../../components/third_party
-    ../../components
-)
-
+set(EXTRA_COMPONENT_DIRS ../../components)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(test)


### PR DESCRIPTION
Previously, we cloned the esp_libcoap component into
components/third_party, and so that dir was added to
EXTRA_COMPONENT_DIRS.

However, esp_libcoap is now relocated to be in
of golioth_sdk/third_party, so there's no need to add
it to EXTRA_COMPONENT_DIRS anymore.

Signed-off-by: Nick Miller <nick@golioth.io>