### PR TITLE
fixes required to build on latest esp-idf

### DIFF
--- a/components/golioth_sdk/CMakeLists.txt
+++ b/components/golioth_sdk/CMakeLists.txt
@@ -41,6 +41,7 @@ idf_component_register(
         "lwip"
         "mbedtls"
         "app_update"
+        "esp_timer"
     SRCS
         "${libcoap_srcs}"
         "golioth_status.c"

--- a/components/golioth_sdk/golioth_coap_client.c
+++ b/components/golioth_sdk/golioth_coap_client.c
@@ -10,7 +10,6 @@
 #include <sys/param.h>  // MIN
 #include <freertos/event_groups.h>
 #include <esp_log.h>
-#include <esp_timer.h>
 #include <coap3/coap.h>
 #include "golioth_client.h"
 #include "golioth_coap_client.h"

--- a/examples/common/shell.c
+++ b/examples/common/shell.c
@@ -9,6 +9,7 @@
 #include "esp_log.h"
 #include "esp_console.h"
 #include "esp_vfs_dev.h"
+#include "esp_chip_info.h"
 #include "driver/uart.h"
 #include "linenoise/linenoise.h"
 #include "argtable3/argtable3.h"

--- a/examples/golioth_basics/main/CMakeLists.txt
+++ b/examples/golioth_basics/main/CMakeLists.txt
@@ -12,6 +12,8 @@ idf_component_register(
         "spi_flash"
         "nvs_flash"
         "json"
+        "driver"
+        "esp_hw_support"
 )
 list(APPEND EXTRA_C_FLAGS_LIST
     -Werror

--- a/examples/magtag_demo/main/leds.c
+++ b/examples/magtag_demo/main/leds.c
@@ -10,6 +10,10 @@
 
 #define TAG "leds"
 
+// TODO - address this warning on recent esp-idf versions:
+// #warning "The legacy RMT driver is deprecated, please use driver/rmt_tx.h and/or driver/rmt_rx.h"
+// [-Werror=cpp]
+
 #define RMT_TX_CHANNEL RMT_CHANNEL_0
 
 #define EXAMPLE_CHASE_SPEED_MS (250)

--- a/examples/test/main/CMakeLists.txt
+++ b/examples/test/main/CMakeLists.txt
@@ -14,6 +14,8 @@ idf_component_register(
         "json"
         "app_update"
         "unity"
+        "driver"
+        "esp_hw_support"
 )
 list(APPEND EXTRA_C_FLAGS_LIST
     -Werror

--- a/examples/test/main/app_main.c
+++ b/examples/test/main/app_main.c
@@ -102,7 +102,7 @@ static void test_lightdb_set_get_sync(void) {
     int randint = rand();
     TEST_ASSERT_EQUAL(GOLIOTH_OK, golioth_lightdb_set_int_sync(_client, "test_int", randint, 3));
 
-    int get_randint = 0;
+    int32_t get_randint = 0;
     TEST_ASSERT_EQUAL(
             GOLIOTH_OK, golioth_lightdb_get_int_sync(_client, "test_int", &get_randint, 3));
     TEST_ASSERT_EQUAL(randint, get_randint);


### PR DESCRIPTION
There are a few warnings and errors if you try to build
on the tip of master esp-idf. This commit fixes the build
errors in a way that is compatible with v4.4.1 (the
version of esp-idf the SDK is tested against).

Signed-off-by: Nick Miller <nick@golioth.io>