### PR TITLE
add callback to all async set/delete functions

### DIFF
--- a/components/golioth_sdk/golioth_coap_client.c
+++ b/components/golioth_sdk/golioth_coap_client.c
@@ -182,6 +182,14 @@ static coap_response_t coap_response_handler(
                     req->get_block.callback(
                             client, &response, req->path, data, data_len, req->get_block.arg);
                 }
+            } else if (req->type == GOLIOTH_COAP_REQUEST_POST) {
+                if (req->post.callback) {
+                    req->post.callback(client, &response, req->path, req->post.arg);
+                }
+            } else if (req->type == GOLIOTH_COAP_REQUEST_DELETE) {
+                if (req->delete.callback) {
+                    req->delete.callback(client, &response, req->path, req->delete.arg);
+                }
             }
         }
     }
@@ -677,11 +685,10 @@ static golioth_status_t coap_io_loop_once(
             request_msg.get.callback(
                     client, &response, request_msg.path, NULL, 0, request_msg.get_block.arg);
         } else if (request_msg.type == GOLIOTH_COAP_REQUEST_POST && request_msg.post.callback) {
-            request_msg.get.callback(
-                    client, &response, request_msg.path, NULL, 0, request_msg.post.arg);
+            request_msg.post.callback(client, &response, request_msg.path, request_msg.post.arg);
         } else if (request_msg.type == GOLIOTH_COAP_REQUEST_DELETE && request_msg.delete.callback) {
-            request_msg.get.callback(
-                    client, &response, request_msg.path, NULL, 0, request_msg.delete.arg);
+            request_msg.delete.callback(
+                    client, &response, request_msg.path, request_msg.delete.arg);
         }
 
         if (client->event_callback && client->session_connected) {

--- a/components/golioth_sdk/golioth_lightdb.c
+++ b/components/golioth_sdk/golioth_lightdb.c
@@ -40,7 +40,9 @@ static golioth_status_t golioth_lightdb_set_int_internal(
         const char* path,
         int32_t value,
         bool is_synchronous,
-        int32_t timeout_s) {
+        int32_t timeout_s,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     char buf[16] = {};
     snprintf(buf, sizeof(buf), "%d", value);
     return golioth_coap_client_set(
@@ -50,8 +52,8 @@ static golioth_status_t golioth_lightdb_set_int_internal(
             COAP_MEDIATYPE_APPLICATION_JSON,
             (const uint8_t*)buf,
             strlen(buf),
-            NULL,
-            NULL,
+            callback,
+            callback_arg,
             is_synchronous,
             timeout_s);
 }
@@ -62,7 +64,9 @@ static golioth_status_t golioth_lightdb_set_bool_internal(
         const char* path,
         bool value,
         bool is_synchronous,
-        int32_t timeout_s) {
+        int32_t timeout_s,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     const char* valuestr = (value ? "true" : "false");
     return golioth_coap_client_set(
             client,
@@ -71,8 +75,8 @@ static golioth_status_t golioth_lightdb_set_bool_internal(
             COAP_MEDIATYPE_APPLICATION_JSON,
             (const uint8_t*)valuestr,
             strlen(valuestr),
-            NULL,
-            NULL,
+            callback,
+            callback_arg,
             is_synchronous,
             timeout_s);
 }
@@ -83,7 +87,9 @@ static golioth_status_t golioth_lightdb_set_float_internal(
         const char* path,
         float value,
         bool is_synchronous,
-        int32_t timeout_s) {
+        int32_t timeout_s,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     char buf[32] = {};
     snprintf(buf, sizeof(buf), "%f", value);
     return golioth_coap_client_set(
@@ -93,8 +99,8 @@ static golioth_status_t golioth_lightdb_set_float_internal(
             COAP_MEDIATYPE_APPLICATION_JSON,
             (const uint8_t*)buf,
             strlen(buf),
-            NULL,
-            NULL,
+            callback,
+            callback_arg,
             is_synchronous,
             timeout_s);
 }
@@ -106,7 +112,9 @@ static golioth_status_t golioth_lightdb_set_string_internal(
         const char* str,
         size_t str_len,
         bool is_synchronous,
-        int32_t timeout_s) {
+        int32_t timeout_s,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     // Server requires that non-JSON-formatted strings
     // be surrounded with literal ".
     //
@@ -129,8 +137,8 @@ static golioth_status_t golioth_lightdb_set_string_internal(
             COAP_MEDIATYPE_APPLICATION_JSON,
             (const uint8_t*)buf,
             bufsize - 1,  // excluding NULL
-            NULL,
-            NULL,
+            callback,
+            callback_arg,
             is_synchronous,
             timeout_s);
 
@@ -144,9 +152,11 @@ static golioth_status_t golioth_lightdb_delete_internal(
         const char* path_prefix,
         const char* path,
         bool is_synchronous,
-        int32_t timeout_s) {
+        int32_t timeout_s,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_coap_client_delete(
-            client, path_prefix, path, NULL, NULL, is_synchronous, timeout_s);
+            client, path_prefix, path, callback, callback_arg, is_synchronous, timeout_s);
 }
 
 static golioth_status_t golioth_lightdb_get_internal(
@@ -175,7 +185,9 @@ static golioth_status_t golioth_lightdb_set_json_internal(
         const char* json_str,
         size_t json_str_len,
         bool is_synchronous,
-        int32_t timeout_s) {
+        int32_t timeout_s,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_coap_client_set(
             client,
             path_prefix,
@@ -183,8 +195,8 @@ static golioth_status_t golioth_lightdb_set_json_internal(
             COAP_MEDIATYPE_APPLICATION_JSON,
             (const uint8_t*)json_str,
             json_str_len,
-            NULL,
-            NULL,
+            callback,
+            callback_arg,
             is_synchronous,
             timeout_s);
 }
@@ -219,32 +231,61 @@ bool golioth_payload_is_null(const uint8_t* payload, size_t payload_size) {
 golioth_status_t golioth_lightdb_set_int_async(
         golioth_client_t client,
         const char* path,
-        int32_t value) {
+        int32_t value,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_int_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
+            path,
+            value,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_set_bool_async(
         golioth_client_t client,
         const char* path,
-        bool value) {
+        bool value,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_bool_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
+            path,
+            value,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_set_float_async(
         golioth_client_t client,
         const char* path,
-        float value) {
+        float value,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_float_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
+            path,
+            value,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_set_string_async(
         golioth_client_t client,
         const char* path,
         const char* str,
-        size_t str_len) {
+        size_t str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_string_internal(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
@@ -252,14 +293,18 @@ golioth_status_t golioth_lightdb_set_string_async(
             str,
             str_len,
             false,
-            GOLIOTH_WAIT_FOREVER);
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_set_json_async(
         golioth_client_t client,
         const char* path,
         const char* json_str,
-        size_t json_str_len) {
+        size_t json_str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_json_internal(
             client,
             GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
@@ -267,7 +312,9 @@ golioth_status_t golioth_lightdb_set_json_async(
             json_str,
             json_str_len,
             false,
-            GOLIOTH_WAIT_FOREVER);
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_get_async(
@@ -285,9 +332,19 @@ golioth_status_t golioth_lightdb_get_async(
             GOLIOTH_WAIT_FOREVER);
 }
 
-golioth_status_t golioth_lightdb_delete_async(golioth_client_t client, const char* path) {
+golioth_status_t golioth_lightdb_delete_async(
+        golioth_client_t client,
+        const char* path,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_delete_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
+            path,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_observe_async(
@@ -311,7 +368,7 @@ golioth_status_t golioth_lightdb_set_int_sync(
         int32_t value,
         int32_t timeout_s) {
     return golioth_lightdb_set_int_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_set_bool_sync(
@@ -320,7 +377,7 @@ golioth_status_t golioth_lightdb_set_bool_sync(
         bool value,
         int32_t timeout_s) {
     return golioth_lightdb_set_bool_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_set_float_sync(
@@ -329,7 +386,7 @@ golioth_status_t golioth_lightdb_set_float_sync(
         float value,
         int32_t timeout_s) {
     return golioth_lightdb_set_float_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, value, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_set_string_sync(
@@ -339,7 +396,15 @@ golioth_status_t golioth_lightdb_set_string_sync(
         size_t str_len,
         int32_t timeout_s) {
     return golioth_lightdb_set_string_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, str, str_len, true, timeout_s);
+            client,
+            GOLIOTH_LIGHTDB_STATE_PATH_PREFIX,
+            path,
+            str,
+            str_len,
+            true,
+            timeout_s,
+            NULL,
+            NULL);
 }
 
 golioth_status_t golioth_lightdb_set_json_sync(
@@ -355,7 +420,9 @@ golioth_status_t golioth_lightdb_set_json_sync(
             json_str,
             json_str_len,
             true,
-            timeout_s);
+            timeout_s,
+            NULL,
+            NULL);
 }
 
 static void on_payload(
@@ -503,38 +570,67 @@ golioth_status_t golioth_lightdb_delete_sync(
         const char* path,
         int32_t timeout_s) {
     return golioth_lightdb_delete_internal(
-            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STATE_PATH_PREFIX, path, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_stream_set_int_async(
         golioth_client_t client,
         const char* path,
-        int32_t value) {
+        int32_t value,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_int_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
+            path,
+            value,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_stream_set_bool_async(
         golioth_client_t client,
         const char* path,
-        bool value) {
+        bool value,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_bool_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
+            path,
+            value,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_stream_set_float_async(
         golioth_client_t client,
         const char* path,
-        float value) {
+        float value,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_float_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, false, GOLIOTH_WAIT_FOREVER);
+            client,
+            GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
+            path,
+            value,
+            false,
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_stream_set_string_async(
         golioth_client_t client,
         const char* path,
         const char* str,
-        size_t str_len) {
+        size_t str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_string_internal(
             client,
             GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
@@ -542,14 +638,18 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
             str,
             str_len,
             false,
-            GOLIOTH_WAIT_FOREVER);
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_stream_set_json_async(
         golioth_client_t client,
         const char* path,
         const char* json_str,
-        size_t json_str_len) {
+        size_t json_str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_lightdb_set_json_internal(
             client,
             GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
@@ -557,7 +657,9 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
             json_str,
             json_str_len,
             false,
-            GOLIOTH_WAIT_FOREVER);
+            GOLIOTH_WAIT_FOREVER,
+            callback,
+            callback_arg);
 }
 
 golioth_status_t golioth_lightdb_stream_set_int_sync(
@@ -566,7 +668,7 @@ golioth_status_t golioth_lightdb_stream_set_int_sync(
         int32_t value,
         int32_t timeout_s) {
     return golioth_lightdb_set_int_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_stream_set_bool_sync(
@@ -575,7 +677,7 @@ golioth_status_t golioth_lightdb_stream_set_bool_sync(
         bool value,
         int32_t timeout_s) {
     return golioth_lightdb_set_bool_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_stream_set_float_sync(
@@ -584,7 +686,7 @@ golioth_status_t golioth_lightdb_stream_set_float_sync(
         float value,
         int32_t timeout_s) {
     return golioth_lightdb_set_float_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, true, timeout_s);
+            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, value, true, timeout_s, NULL, NULL);
 }
 
 golioth_status_t golioth_lightdb_stream_set_string_sync(
@@ -594,7 +696,15 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
         size_t str_len,
         int32_t timeout_s) {
     return golioth_lightdb_set_string_internal(
-            client, GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX, path, str, str_len, true, timeout_s);
+            client,
+            GOLIOTH_LIGHTDB_STREAM_PATH_PREFIX,
+            path,
+            str,
+            str_len,
+            true,
+            timeout_s,
+            NULL,
+            NULL);
 }
 
 golioth_status_t golioth_lightdb_stream_set_json_sync(
@@ -610,5 +720,7 @@ golioth_status_t golioth_lightdb_stream_set_json_sync(
             json_str,
             json_str_len,
             true,
-            timeout_s);
+            timeout_s,
+            NULL,
+            NULL);
 }

--- a/components/golioth_sdk/golioth_log.c
+++ b/components/golioth_sdk/golioth_log.c
@@ -61,7 +61,9 @@ static golioth_status_t golioth_log_internal(
 golioth_status_t golioth_log_error_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message) {
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_log_internal(
             client, GOLIOTH_LOG_LEVEL_ERROR, tag, log_message, false, GOLIOTH_WAIT_FOREVER);
 }
@@ -69,7 +71,9 @@ golioth_status_t golioth_log_error_async(
 golioth_status_t golioth_log_warn_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message) {
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_log_internal(
             client, GOLIOTH_LOG_LEVEL_WARN, tag, log_message, false, GOLIOTH_WAIT_FOREVER);
 }
@@ -77,7 +81,9 @@ golioth_status_t golioth_log_warn_async(
 golioth_status_t golioth_log_info_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message) {
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_log_internal(
             client, GOLIOTH_LOG_LEVEL_INFO, tag, log_message, false, GOLIOTH_WAIT_FOREVER);
 }
@@ -85,7 +91,9 @@ golioth_status_t golioth_log_info_async(
 golioth_status_t golioth_log_debug_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message) {
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg) {
     return golioth_log_internal(
             client, GOLIOTH_LOG_LEVEL_DEBUG, tag, log_message, false, GOLIOTH_WAIT_FOREVER);
 }

--- a/components/golioth_sdk/include/golioth_lightdb.h
+++ b/components/golioth_sdk/include/golioth_lightdb.h
@@ -15,7 +15,6 @@ bool golioth_payload_as_bool(const uint8_t* payload, size_t payload_size);
 bool golioth_payload_is_null(const uint8_t* payload, size_t payload_size);
 
 // TODO - block transfers for large post/get
-// TODO (maybe) - add callbacks to async set/delete APIs, in case user wants to handle errors
 
 //
 // LightDB State
@@ -25,7 +24,9 @@ bool golioth_payload_is_null(const uint8_t* payload, size_t payload_size);
 golioth_status_t golioth_lightdb_set_int_async(
         golioth_client_t client,
         const char* path,
-        int32_t value);
+        int32_t value,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_set_int_sync(
         golioth_client_t client,
         const char* path,
@@ -34,7 +35,9 @@ golioth_status_t golioth_lightdb_set_int_sync(
 golioth_status_t golioth_lightdb_set_bool_async(
         golioth_client_t client,
         const char* path,
-        bool value);
+        bool value,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_set_bool_sync(
         golioth_client_t client,
         const char* path,
@@ -43,7 +46,9 @@ golioth_status_t golioth_lightdb_set_bool_sync(
 golioth_status_t golioth_lightdb_set_float_async(
         golioth_client_t client,
         const char* path,
-        float value);
+        float value,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_set_float_sync(
         golioth_client_t client,
         const char* path,
@@ -53,7 +58,9 @@ golioth_status_t golioth_lightdb_set_string_async(
         golioth_client_t client,
         const char* path,
         const char* str,
-        size_t str_len);
+        size_t str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_set_string_sync(
         golioth_client_t client,
         const char* path,
@@ -64,7 +71,9 @@ golioth_status_t golioth_lightdb_set_json_async(
         golioth_client_t client,
         const char* path,
         const char* json_str,
-        size_t json_str_len);
+        size_t json_str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_set_json_sync(
         golioth_client_t client,
         const char* path,
@@ -107,7 +116,11 @@ golioth_status_t golioth_lightdb_get_json_sync(
         int32_t timeout_s);
 
 // delete
-golioth_status_t golioth_lightdb_delete_async(golioth_client_t client, const char* path);
+golioth_status_t golioth_lightdb_delete_async(
+        golioth_client_t client,
+        const char* path,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_delete_sync(
         golioth_client_t client,
         const char* path,
@@ -127,7 +140,9 @@ golioth_status_t golioth_lightdb_observe_async(
 golioth_status_t golioth_lightdb_stream_set_int_async(
         golioth_client_t client,
         const char* path,
-        int32_t value);
+        int32_t value,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_stream_set_int_sync(
         golioth_client_t client,
         const char* path,
@@ -136,7 +151,9 @@ golioth_status_t golioth_lightdb_stream_set_int_sync(
 golioth_status_t golioth_lightdb_stream_set_bool_async(
         golioth_client_t client,
         const char* path,
-        bool value);
+        bool value,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_stream_set_bool_sync(
         golioth_client_t client,
         const char* path,
@@ -145,7 +162,9 @@ golioth_status_t golioth_lightdb_stream_set_bool_sync(
 golioth_status_t golioth_lightdb_stream_set_float_async(
         golioth_client_t client,
         const char* path,
-        float value);
+        float value,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_stream_set_float_sync(
         golioth_client_t client,
         const char* path,
@@ -155,7 +174,9 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
         golioth_client_t client,
         const char* path,
         const char* str,
-        size_t str_len);
+        size_t str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_stream_set_string_sync(
         golioth_client_t client,
         const char* path,
@@ -166,7 +187,9 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
         golioth_client_t client,
         const char* path,
         const char* json_str,
-        size_t json_str_len);
+        size_t json_str_len,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_lightdb_stream_set_json_sync(
         golioth_client_t client,
         const char* path,

--- a/components/golioth_sdk/include/golioth_log.h
+++ b/components/golioth_sdk/include/golioth_log.h
@@ -19,19 +19,27 @@ typedef enum {
 golioth_status_t golioth_log_error_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message);
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_log_warn_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message);
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_log_info_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message);
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 golioth_status_t golioth_log_debug_async(
         golioth_client_t client,
         const char* tag,
-        const char* log_message);
+        const char* log_message,
+        golioth_set_cb_fn callback,
+        void* callback_arg);
 
 // Sync APIs (blocking, wait for server response or timeout)
 golioth_status_t golioth_log_error_sync(

--- a/examples/golioth_basics/main/app_main.c
+++ b/examples/golioth_basics/main/app_main.c
@@ -47,7 +47,7 @@ static void on_my_setting(
     int32_t desired_value = golioth_payload_as_int(payload, payload_size);
     ESP_LOGI(TAG, "Cloud desires %s = %d. Setting now.", path, desired_value);
     *actual_value_ptr = desired_value;
-    golioth_lightdb_delete_async(client, path);
+    golioth_lightdb_delete_async(client, path, NULL, NULL);
 }
 
 static void example_json_set_async(golioth_client_t client) {
@@ -58,7 +58,7 @@ static void example_json_set_async(golioth_client_t client) {
     bool printed = cJSON_PrintPreallocated(json, jsonbuf, sizeof(jsonbuf) - 5, false);
     assert(printed);
     cJSON_Delete(json);
-    golioth_lightdb_set_json_async(client, "example_json", jsonbuf, strlen(jsonbuf));
+    golioth_lightdb_set_json_async(client, "example_json", jsonbuf, strlen(jsonbuf), NULL, NULL);
 }
 
 static void on_example_json(
@@ -148,12 +148,12 @@ void app_main(void) {
         }
 
         // Asynchronous API examples (non-blocking, doesn't wait for server response)
-        golioth_log_info_async(client, TAG, "This is a message");
-        golioth_lightdb_set_int_async(client, "iteration", iteration);
-        golioth_lightdb_set_int_async(client, "my_setting", my_setting);
-        golioth_lightdb_set_float_async(client, "float_value", float_value);
+        golioth_log_info_async(client, TAG, "This is a message", NULL, NULL);
+        golioth_lightdb_set_int_async(client, "iteration", iteration, NULL, NULL);
+        golioth_lightdb_set_int_async(client, "my_setting", my_setting, NULL, NULL);
+        golioth_lightdb_set_float_async(client, "float_value", float_value, NULL, NULL);
         golioth_lightdb_set_string_async(
-                client, "string_value", string_value, strlen(string_value));
+                client, "string_value", string_value, strlen(string_value), NULL, NULL);
 
         golioth_lightdb_get_async(client, "float_value_a", on_float_value, (void*)0);
         golioth_lightdb_get_async(client, "float_value_b", on_float_value, (void*)1);

--- a/examples/magtag_demo/main/app_main.c
+++ b/examples/magtag_demo/main/app_main.c
@@ -81,7 +81,7 @@ static void on_desired_buzz(
 
     if (buzz) {
         speaker_play_audio(coin_audio, sizeof(coin_audio), COIN_SAMPLE_RATE);
-        golioth_lightdb_delete_async(client, path);
+        golioth_lightdb_delete_async(client, path, NULL, NULL);
     }
 }
 
@@ -110,7 +110,7 @@ static void on_desired_text(
     ESP_LOGI(TAG, "Got desired/text = %s", text);
     write_text(text, strlen(text));
     cJSON_Delete(json);
-    golioth_lightdb_delete_async(client, path);
+    golioth_lightdb_delete_async(client, path, NULL, NULL);
 }
 
 static void set_led_from_json(uint32_t led_index, const cJSON* json) {
@@ -159,7 +159,7 @@ static void on_desired_leds(
     set_led_from_json(3, cJSON_GetObjectItemCaseSensitive(json, "3"));
 
     cJSON_Delete(json);
-    golioth_lightdb_delete_async(client, path);
+    golioth_lightdb_delete_async(client, path, NULL, NULL);
 }
 
 static const char* led_color_to_str(uint32_t color) {
@@ -194,7 +194,7 @@ static void publish_state(golioth_client_t client) {
     bool printed = cJSON_PrintPreallocated(root, jsonbuf, sizeof(jsonbuf) - 5, false);
     assert(printed);
     cJSON_Delete(root);
-    golioth_lightdb_set_json_async(client, "state", jsonbuf, strlen(jsonbuf));
+    golioth_lightdb_set_json_async(client, "state", jsonbuf, strlen(jsonbuf), NULL, NULL);
 }
 
 static void app_gpio_init(void) {


### PR DESCRIPTION
Previously, there was no way to be notified when a set or
delete async call received a response from the server,
and no way to know if there was an error.

This commit changes the existing set and delete async
functions to also pass optional callback function and
void* callback arg.

This is immediately useful in the test example
(test_lightdb_set_get_async), to avoid waiting "in the dark"
for an async set call to receive a response, and it seems
like it will be generally useful for SDK users, at the expense
of a couple of extra parameters at the call site.

Signed-off-by: Nick Miller <nick@golioth.io>