### PR TITLE
coap_client: fix incorrect callback for GET_BLOCK

### DIFF
--- a/components/golioth_sdk/golioth_coap_client.c
+++ b/components/golioth_sdk/golioth_coap_client.c
@@ -682,7 +682,7 @@ static golioth_status_t coap_io_loop_once(
         } else if (
                 request_msg.type == GOLIOTH_COAP_REQUEST_GET_BLOCK
                 && request_msg.get_block.callback) {
-            request_msg.get.callback(
+            request_msg.get_block.callback(
                     client, &response, request_msg.path, NULL, 0, request_msg.get_block.arg);
         } else if (request_msg.type == GOLIOTH_COAP_REQUEST_POST && request_msg.post.callback) {
             request_msg.post.callback(client, &response, request_msg.path, request_msg.post.arg);

--- a/components/golioth_sdk/golioth_fw_update.c
+++ b/components/golioth_sdk/golioth_fw_update.c
@@ -174,7 +174,7 @@ static golioth_status_t fw_update_download_and_write_flash(void) {
     if (bytes_written != _main_component->size) {
         ESP_LOGE(
                 TAG,
-                "Download interrupted, wrote %zu of %zu bytes",
+                "Download failed, downloaded size %zu does not match manifest size %zu",
                 bytes_written,
                 _main_component->size);
         ESP_LOGI(TAG, "State = Idle");


### PR DESCRIPTION
Previously, if a GET_BLOCK request timed out, the wrong
callback was being called (calling request_msg.get instead
of request_msg.get_block), resulting in a crash.

Signed-off-by: Nick Miller <nick@golioth.io>