### PR TITLE
test: increase timeout for initial connect

### DIFF
--- a/examples/test/main/app_main.c
+++ b/examples/test/main/app_main.c
@@ -63,7 +63,7 @@ static void test_golioth_client_create(void) {
 static void test_connects_to_golioth(void) {
     TEST_ASSERT_NOT_NULL(_client);
     TEST_ASSERT_EQUAL(GOLIOTH_OK, golioth_client_start(_client));
-    TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(_connected_sem, 5000 / portTICK_PERIOD_MS));
+    TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(_connected_sem, 10000 / portTICK_PERIOD_MS));
 }
 
 static void test_golioth_client_heap_usage(void) {


### PR DESCRIPTION
The server sometimes takes a very long time to connect and
respond to the initial empty request, for example:

D (14214) golioth_coap_client: Received response in 9616 ms

For now, we will increase the timeout to 10 s, which should
at least reduce the chance of timeout happening.

Signed-off-by: Nick Miller <nick@golioth.io>