### PR TITLE
verify.py: Increase timeout for OTA start

### DIFF
--- a/examples/test/verify.py
+++ b/examples/test/verify.py
@@ -92,7 +92,7 @@ def run_ota_test(ser):
     ser.write('\r\n'.encode())
     wait_for_str_in_line(ser, 'esp32>')
     ser.write('start_ota\r\n'.encode())
-    wait_for_str_in_line(ser, 'State = Downloading')
+    wait_for_str_in_line(ser, 'State = Downloading', 20)
     wait_for_str_in_line(ser, 'Erasing flash')
     wait_for_str_in_line(ser, 'Received response')
 


### PR DESCRIPTION
Sometimes CI will timeout waiting for to see "State = Downloading"
from the device. This is happening because the initial empty
keepalive for the CoAP session sometimes doesn't get a response
from the server for a very long time (5+ seconds).

Doubling the timeout for that step should fix the flaky test.

Signed-off-by: Nick Miller <nick@golioth.io>