### PR TITLE
verify.py: increase timeout to 20s by default

### DIFF
--- a/examples/test/verify.py
+++ b/examples/test/verify.py
@@ -5,7 +5,7 @@ from time import time
 import re
 import json
 
-def wait_for_str_in_line(ser, str, timeout_s=10, log=True):
+def wait_for_str_in_line(ser, str, timeout_s=20, log=True):
     start_time = time()
     while True:
         line = ser.readline().decode('utf-8', errors='replace').replace("\r\n", "")
@@ -92,7 +92,7 @@ def run_ota_test(ser):
     ser.write('\r\n'.encode())
     wait_for_str_in_line(ser, 'esp32>')
     ser.write('start_ota\r\n'.encode())
-    wait_for_str_in_line(ser, 'State = Downloading', 20)
+    wait_for_str_in_line(ser, 'State = Downloading')
     wait_for_str_in_line(ser, 'Erasing flash')
     wait_for_str_in_line(ser, 'Received response')
 


### PR DESCRIPTION
Similar to 498be374d844e32d4d325ec6608b6498f696e0b9,
CI is flaky due to unreliable repsonse times from the server
on a cold reboot.

Setting the default timeout to 20 for wait_for_str_in_line
should fix it (fingers crossed).

Signed-off-by: Nick Miller <nick@golioth.io>