### PR TITLE
test: start_ota should run in Unity context

### DIFF
--- a/examples/test/main/app_main.c
+++ b/examples/test/main/app_main.c
@@ -28,7 +28,7 @@ static uint32_t _initial_free_heap;
 static bool _wifi_connected;
 
 // Note: Don't put TEST_ASSERT_* statements in client callback functions, as this
-// will cause a stack overflow in the client task is any of the assertions fail.
+// will cause a stack overflow in the client task if any of the assertions fail.
 //
 // I'm not sure exactly why this happens, but I suspect it's related to
 // Unity's UNITY_FAIL_AND_BAIL macro that gets called on failing assertions.
@@ -383,12 +383,15 @@ static int built_in_test(int argc, char** argv) {
 }
 
 static int start_ota(int argc, char** argv) {
-    test_connects_to_wifi();
+    UNITY_BEGIN();
+    RUN_TEST(test_connects_to_wifi);
     if (!_client) {
-        test_golioth_client_create();
-        test_connects_to_golioth();
+        RUN_TEST(test_golioth_client_create);
+        RUN_TEST(test_connects_to_golioth);
     }
     golioth_fw_update_init(_client, _current_version);
+    UNITY_END();
+
     return 0;
 }
 


### PR DESCRIPTION
Fix for: https://golioth.atlassian.net/browse/DSDK-316

---
The prior code would crash in the start_ota shell command
if any of the Unity TEST_ASSERT_* assertions failed.
This was happening occassionally in CI if the initial
EMPTY request was not responded to within 10 seconds
(which is a separate issue).

I think the reason the crash occurs is because those
assert macros only work in the context of a Unity session
(indicated by UNITY_BEGIN and UNITY_END macros).

To fix, the start_ota command now executes the
connect functions in the context of a Unity test
session, similar to built_in_test.

Signed-off-by: Nick Miller <nick@golioth.io>