### PR TITLE
test: use YAML instead of JSON for credentials

### DIFF
--- a/.github/workflows/test_esp32s3.yml
+++ b/.github/workflows/test_esp32s3.yml
@@ -87,11 +87,11 @@ jobs:
         tar xvf build.tar.gz
     - name: Install esptool
       run: pip install esptool
-    # Assume the self-hosted runner has a $HOME/credentials.json file
+    # Assume the self-hosted runner has a $HOME/credentials.yml file
     # that sets the local WiFi ssid/password and Golioth psk-id/psk.
-    - name: Copy credentials.json to examples/test
+    - name: Copy credentials.yml to examples/test
       run: |
-        cp $HOME/credentials.json examples/test
+        cp $HOME/credentials.yml examples/test
     - name: Flash and Verify Serial Output
       run: |
         cd examples/test

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ build/
 sdkconfig
 sdkconfig.old
 build.tar.gz
-credentials.json
+credentials.yml
 .vscode

--- a/examples/test/README.md
+++ b/examples/test/README.md
@@ -8,20 +8,27 @@ the pass/fail result of each test.
 The script will return with an exit code equal to the number of
 failed tests (0 means all tests passed), or -1 for general error.
 
-The verify.py script requires a file named `credentials.json` (ignored by git) in
+The verify.py script requires a file named `credentials.yml` (ignored by git) in
 order to provision Wi-Fi and Golioth credentials to the device:
 
-```py
-{
-  "wifi/ssid": "MySSID",
-  "wifi/psk": "secretpassword",
-  "golioth/psk-id": "device@project",
-  "golioth/psk": "supersecret"
-}
+```yaml
+settings:
+  wifi/ssid: MyWiFiSSID
+  wifi/psk: MyWiFiPassword
+  golioth/psk-id: device@project
+  golioth/psk: supersecret
 ```
+
+### Install Pre-Requisities
+
+```sh
+pip install pyyaml
+```
+
+### Run Test
 
 To build, flash, and run the tests:
 
 ```sh
-idf.py build && python flash.py && python verify.py
+idf.py build && python flash.py && python verify.py /dev/ttyUSB0
 ```

--- a/examples/test/verify.py
+++ b/examples/test/verify.py
@@ -3,7 +3,7 @@ import os
 import serial
 from time import time
 import re
-import json
+import yaml
 
 def wait_for_str_in_line(ser, str, timeout_s=20, log=True):
     start_time = time()
@@ -19,24 +19,18 @@ def wait_for_str_in_line(ser, str, timeout_s=20, log=True):
             return line
 
 def set_credentials(ser):
-    with open('credentials.json', 'r') as f:
-        settings = json.load(f)
+    with open('credentials.yml', 'r') as f:
+        credentials = yaml.safe_load(f)
 
     print('===== Setting credentials via CLI (logging disabled) ====')
     ser.write('\r\n'.encode())
     wait_for_str_in_line(ser, 'esp32>', log=False)
-    ser.write('settings set wifi/ssid {}\r\n'.format(settings['wifi/ssid']).encode())
-    wait_for_str_in_line(ser, 'saved', log=False)
-    wait_for_str_in_line(ser, 'esp32>', log=False)
-    ser.write('settings set wifi/psk {}\r\n'.format(settings['wifi/psk']).encode())
-    wait_for_str_in_line(ser, 'saved', log=False)
-    wait_for_str_in_line(ser, 'esp32>', log=False)
-    ser.write('settings set golioth/psk-id {}\r\n'.format(settings['golioth/psk-id']).encode())
-    wait_for_str_in_line(ser, 'saved', log=False)
-    wait_for_str_in_line(ser, 'esp32>', log=False)
-    ser.write('settings set golioth/psk {}\r\n'.format(settings['golioth/psk']).encode())
-    wait_for_str_in_line(ser, 'saved', log=False)
-    wait_for_str_in_line(ser, 'esp32>', log=False)
+
+    settings = credentials['settings']
+    for key, value in settings.items():
+        ser.write('settings set {} {}\r\n'.format(key, value).encode())
+        wait_for_str_in_line(ser, 'saved', log=False)
+        wait_for_str_in_line(ser, 'esp32>', log=False)
 
 def reset(ser):
     ser.write('\r\n'.encode())


### PR DESCRIPTION
YAML is cleaner and makes it easy to iterate over all settings
without having to code them explictly in verify.py.

Signed-off-by: Nick Miller <nick@golioth.io>