### PR TITLE
treewide: fix 'LightDB Stream' spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The `examples` directory contains example apps which you can build and run.
 The `golioth_basics` example is recommended as a starting point, to learn how to
 connect to Golioth and use services like
 [LightDB state](https://docs.golioth.io/cloud/services/lightdb),
-[LightDB stream](https://docs.golioth.io/cloud/services/lightdb-stream),
+[LightDB Stream](https://docs.golioth.io/cloud/services/lightdb-stream),
 [Logging](https://docs.golioth.io/cloud/services/logging),
 and [OTA](https://docs.golioth.io/cloud/services/ota).
 

--- a/components/golioth_sdk/include/golioth_lightdb.h
+++ b/components/golioth_sdk/include/golioth_lightdb.h
@@ -9,7 +9,7 @@
 #include "golioth_client.h"
 
 /// @defgroup golioth_lightdb golioth_lightdb
-/// Functions for interacting with Golioth LightDB state and LightDB stream services.
+/// Functions for interacting with Golioth LightDB state and LightDB Stream services.
 ///
 /// https://docs.golioth.io/reference/protocols/coap/lightdb
 /// <br>
@@ -357,7 +357,7 @@ golioth_status_t golioth_lightdb_observe_async(
 // LightDB Stream
 //-------------------------------------------------------------------------------
 
-/// Similar to @ref golioth_lightdb_set_int_async, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_int_async, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_int_async(
         golioth_client_t client,
         const char* path,
@@ -365,14 +365,14 @@ golioth_status_t golioth_lightdb_stream_set_int_async(
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-/// Similar to @ref golioth_lightdb_set_int_sync, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_int_sync, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_int_sync(
         golioth_client_t client,
         const char* path,
         int32_t value,
         int32_t timeout_s);
 
-/// Similar to @ref golioth_lightdb_set_bool_async, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_bool_async, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_bool_async(
         golioth_client_t client,
         const char* path,
@@ -380,14 +380,14 @@ golioth_status_t golioth_lightdb_stream_set_bool_async(
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-/// Similar to @ref golioth_lightdb_set_bool_sync, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_bool_sync, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_bool_sync(
         golioth_client_t client,
         const char* path,
         bool value,
         int32_t timeout_s);
 
-/// Similar to @ref golioth_lightdb_set_float_async, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_float_async, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_float_async(
         golioth_client_t client,
         const char* path,
@@ -395,14 +395,14 @@ golioth_status_t golioth_lightdb_stream_set_float_async(
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-/// Similar to @ref golioth_lightdb_set_float_sync, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_float_sync, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_float_sync(
         golioth_client_t client,
         const char* path,
         float value,
         int32_t timeout_s);
 
-/// Similar to @ref golioth_lightdb_set_string_async, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_string_async, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_string_async(
         golioth_client_t client,
         const char* path,
@@ -411,7 +411,7 @@ golioth_status_t golioth_lightdb_stream_set_string_async(
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-/// Similar to @ref golioth_lightdb_set_string_sync, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_string_sync, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_string_sync(
         golioth_client_t client,
         const char* path,
@@ -419,7 +419,7 @@ golioth_status_t golioth_lightdb_stream_set_string_sync(
         size_t str_len,
         int32_t timeout_s);
 
-/// Similar to @ref golioth_lightdb_set_json_async, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_json_async, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_json_async(
         golioth_client_t client,
         const char* path,
@@ -428,7 +428,7 @@ golioth_status_t golioth_lightdb_stream_set_json_async(
         golioth_set_cb_fn callback,
         void* callback_arg);
 
-/// Similar to @ref golioth_lightdb_set_json_sync, but for LightDB stream
+/// Similar to @ref golioth_lightdb_set_json_sync, but for LightDB Stream
 golioth_status_t golioth_lightdb_stream_set_json_sync(
         golioth_client_t client,
         const char* path,

--- a/examples/golioth_basics/README.md
+++ b/examples/golioth_basics/README.md
@@ -1,7 +1,7 @@
 # Golioth Basics Example
 
 This example will connect to Golioth and demonstrate Logging, Over-the-Air (OTA)
-firmware updates, and sending data to both LightDB state and LightDB stream.
+firmware updates, and sending data to both LightDB state and LightDB Stream.
 Please see the comments in app_main.c for a thorough explanation of the expected
 behavior.
 

--- a/examples/golioth_basics/main/app_main.c
+++ b/examples/golioth_basics/main/app_main.c
@@ -179,7 +179,7 @@ void app_main(void) {
     //      Logging
     //      Over-the-Air (OTA) firmware updates
     //      LightDB state
-    //      LightDB stream
+    //      LightDB Stream
 
     // We'll start by logging a message to Golioth.
     //
@@ -252,7 +252,7 @@ void app_main(void) {
     // Once set, the on_my_config callback function should be called here.
     golioth_lightdb_observe_async(client, "desired/my_config", on_my_config, NULL);
 
-    // LightDB stream functions are nearly identical to LightDB state.
+    // LightDB Stream functions are nearly identical to LightDB state.
     golioth_lightdb_stream_set_int_async(client, "my_stream_int", 15, NULL, NULL);
 
     // We can register Remote Procedure Call (RPC) methods. RPCs allow


### PR DESCRIPTION
Following command was executed in root directory:
```
  $ sed -i 's/LightDB stream/LightDB Stream/g' `find -type f`
```