### PR TITLE
Found minor issue in MagTag demo's README.md.  -b flag can't be used as written, and turns out to be not needed.

### DIFF
--- a/examples/magtag_demo/README.md
+++ b/examples/magtag_demo/README.md
@@ -51,7 +51,7 @@ the board into the new firmware.
 You can use the ESP-IDF monitor feature to see the serial output of the MagTag.
 
 ```sh
-idp.py -p /dev/ttyACM0 -b monitor
+idp.py -p /dev/ttyACM0 monitor
 ```
 
 Exit the monitor by typing `CTRL-]`.


### PR DESCRIPTION
Removing the -b flag from the monitor command.

The -b flag is to set the baud rate, and requires a parameter after it.  The command works without it.